### PR TITLE
Corrections for mindthief and tinkerer

### DIFF
--- a/src/lib/classes/index.js
+++ b/src/lib/classes/index.js
@@ -281,7 +281,7 @@ const CLASSES = {
                 used: [false, false],
                 modifyCards: (cards) =>
                     new CardsModifier(cards)
-                    .addCards(1, {modifier: NUMBER_MODIFIERS.PLUS_ZERO, extra: elements.ICE})
+                    .addCards(1, {modifier: NUMBER_MODIFIERS.PLUS_TWO, extra: elements.ICE})
                     .cards(),
             },
             {

--- a/src/lib/classes/index.js
+++ b/src/lib/classes/index.js
@@ -575,7 +575,7 @@ const CLASSES = {
                 modifyCards: (cards) =>
                     new CardsModifier(cards)
                     .removeCards(1, BASE_CARDS.MINUS_TWO)
-                    .addCards(1, BASE_CARDS.PLUS_ONE)
+                    .addCards(1, BASE_CARDS.PLUS_ZERO)
                     .cards(),
             },
             {


### PR DESCRIPTION
Hi there,
First off, thanks for the great tool. I noticed that one of the Tinkerers perks had a typo. Description was right, but the perk itself added the wrong card. As I was tinkering in the code anyway I thought I just open a PR to save you some time.
Cheers,
Michael
PS: I added one of the unlockable classes, let me know if you are interested in a PR for those as well. I used the spoiler-friendly classname, but the HP and perks are of course spoilery by themselves. I'm fine keeping that in my fork, if you prefer to keep your version spoiler-free.
PPS: Found another small issue with Mindthief perks and created a new PR with both corrections